### PR TITLE
Add versions up to 3.22 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,8 +2,11 @@
   "description": "Search wikidata.org directly from GNOME Shell",
   "name": "Wikidata Search Provider",
   "shell-version": [
-      "3.14",
-	  "3.16"
+    "3.14",
+    "3.16",
+    "3.18",
+    "3.20",
+    "3.22"
   ],
   "url": "https://github.com/6ahodir/wikidata-search-provider",
   "uuid": "wikidata-search-provider@6ahodir.gmail.com",


### PR DESCRIPTION
Just tested it with Gnome 3.22 and it works fine.